### PR TITLE
Feature: Apple Silicon (M1) Support

### DIFF
--- a/build-mac/dependencies/prepare-cyrus-sasl.sh
+++ b/build-mac/dependencies/prepare-cyrus-sasl.sh
@@ -221,7 +221,7 @@ echo "*** creating xcframework ***" >> "$logfile" 2>&1
 xcodebuild -create-xcframework \
  -library "${INSTALL_PATH}/iPhoneOS/lib/libsasl2.a" \
  -library "${INSTALL_PATH}/iPhoneSimulator/lib/libsasl2.a" \
- -output "${INSTALL_PATH}/sasl.xcframework"
+ -output "${INSTALL_PATH}/lib/sasl.xcframework"
 
 if [[ "$?" != "0" ]]; then
   echo "BUILD FAILED"
@@ -234,7 +234,7 @@ echo "*** creating built package ***" >> "$logfile" 2>&1
 
 cd "$BUILD_DIR"
 mkdir -p libsasl-ios
-cp -R "${INSTALL_PATH}/sasl.xcframework" libsasl-ios
+cp -R "${INSTALL_PATH}/lib" libsasl-ios
 cp -R "${INSTALL_PATH}/include" libsasl-ios
 tar -czf "libsasl-$version-ios.tar.gz" libsasl-ios
 mkdir -p "$resultdir"

--- a/build-mac/dependencies/prepare-cyrus-sasl.sh
+++ b/build-mac/dependencies/prepare-cyrus-sasl.sh
@@ -130,30 +130,36 @@ for TARGET in $TARGETS; do
 
     case $TARGET in
         (iPhoneOS)
-            ARCH=arm
-            MARCHS="armv7 armv7s arm64"
+            TARGET_TRIPLES=("armv7-apple-ios$SDK_IOS_MIN_VERSION" "armv7s-apple-ios$SDK_IOS_MIN_VERSION" "arm64-apple-ios$SDK_IOS_MIN_VERSION")
+            HOST_TRIPLES=("armv7-apple-darwin" "armv7s-apple-darwin" "aarch64-apple-darwin")
+            MARCHS=("armv7" "armv7s" "arm64")
             EXTRA_FLAGS="$BITCODE_FLAGS -miphoneos-version-min=$SDK_IOS_MIN_VERSION"
             ;;
         (iPhoneSimulator)
-            ARCH=i386
-            MARCHS="i386 x86_64"
+            TARGET_TRIPLES=("i386-apple-ios$SDK_IOS_MIN_VERSION-simulator" "x86_64-apple-ios$SDK_IOS_MIN_VERSION-simulator" "arm64-apple-ios$SDK_IOS_MIN_VERSION-simulator")
+            HOST_TRIPLES=("i386-apple-darwin" "x86_64-apple-darwin" "aarch64-apple-darwin")
+            MARCHS=("i386" "x86_64" "arm64")
             EXTRA_FLAGS="-miphoneos-version-min=$SDK_IOS_MIN_VERSION"
             ;;
     esac
 
-    for MARCH in $MARCHS; do
-				echo "building for $TARGET - $MARCH"
-				echo "*** building for $TARGET - $MARCH ***" >> "$logfile" 2>&1
+    for i in "${!TARGET_TRIPLES[@]}"; do 
+        TARGET_TRIPLE="${TARGET_TRIPLES[$i]}"
+        HOST_TRIPLE="${HOST_TRIPLES[$i]}"
+        MARCH="${MARCHS[$i]}"
 
+        echo "building for $TARGET - $MARCH (host: $HOST_TRIPLE, target: $TARGET_TRIPLE)"
+        echo "*** building for $TARGET - $MARCH (host: $HOST_TRIPLE, target: $TARGET_TRIPLE) ***" >> "$logfile" 2>&1
+        
         PREFIX=${BUILD_DIR}/${LIB_NAME}/${TARGET}${SDK_IOS_VERSION}${MARCH}
         rm -rf $PREFIX
 
-        export CPPFLAGS="-arch ${MARCH} -isysroot ${SYSROOT}"
+        export CPPFLAGS="-target ${TARGET_TRIPLE} -isysroot ${SYSROOT}"
         export CFLAGS="${CPPFLAGS} -Os ${EXTRA_FLAGS}"
 
         OPENSSL="--with-openssl=$BUILD_DIR/openssl-1.0.0d/universal"
         PLUGINS="--enable-otp=no --enable-digest=no --with-des=no --enable-login"
-        ./configure --host=${ARCH} --prefix=$PREFIX --enable-shared=no --enable-static=yes --with-pam=$BUILD_DIR/openpam-20071221/universal $PLUGINS >> "$logfile" 2>&1
+        ./configure --host=${HOST_TRIPLE} --prefix=$PREFIX --enable-shared=no --enable-static=yes --with-pam=$BUILD_DIR/openpam-20071221/universal $PLUGINS >> "$logfile" 2>&1
         make -j 8 >> "$logfile" 2>&1
         if [[ "$?" != "0" ]]; then
           echo "CONFIGURE FAILED"
@@ -197,7 +203,13 @@ for lib in $ALL_LIBS; do
     for TARGET in $TARGETS; do
         LIBS="$LIBS ${BUILD_DIR}/${LIB_NAME}/${TARGET}${SDK_IOS_VERSION}*/lib/${lib}"
     done
+    echo "lipo -create ${LIBS} -output '${INSTALL_PATH}/lib/${lib}'"
     lipo -create ${LIBS} -output "${INSTALL_PATH}/lib/${lib}"
+    if [[ "$?" != "0" ]]; then
+      echo "BUILD FAILED"
+      cat "$logfile"
+      exit 1
+    fi
 done
 
 echo "*** creating built package ***" >> "$logfile" 2>&1

--- a/build-mac/dependencies/prepare-cyrus-sasl.sh
+++ b/build-mac/dependencies/prepare-cyrus-sasl.sh
@@ -226,6 +226,19 @@ for TARGET in $TARGETS; do
     # fi
 done
 
+echo "creating xcframework"
+echo "*** creating xcframework ***" >> "$logfile" 2>&1
+xcodebuild -create-xcframework \
+ -library "${INSTALL_PATH}/iPhoneOS/lib/libsasl2.a" -headers "${INSTALL_PATH}/include" \
+ -library "${INSTALL_PATH}/iPhoneSimulator/lib/libsasl2.a" -headers "${INSTALL_PATH}/include" \
+ -output sasl2.xcframework
+
+if [[ "$?" != "0" ]]; then
+  echo "BUILD FAILED"
+  cat "$logfile"
+  exit 1
+fi
+
 exit 1
 
 echo "*** creating built package ***" >> "$logfile" 2>&1

--- a/build-mac/libetpan.xcodeproj/project.pbxproj
+++ b/build-mac/libetpan.xcodeproj/project.pbxproj
@@ -1887,7 +1887,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "cp \"$SRCROOT/libsasl-ios/lib/libsasl2.a\" \"$BUILT_PRODUCTS_DIR\"\n";
+			shellScript = "cp -R \"$SRCROOT/libsasl-ios/sasl.xcframework\" \"$BUILT_PRODUCTS_DIR\"\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -2591,7 +2591,6 @@
 				);
 				INSTALL_PATH = /usr/local/lib;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				LIBRARY_SEARCH_PATHS = "$(SRCROOT)/libsasl-ios/lib";
 				PRODUCT_NAME = "etpan-ios";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
@@ -2612,7 +2611,6 @@
 				);
 				INSTALL_PATH = /usr/local/lib;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				LIBRARY_SEARCH_PATHS = "$(SRCROOT)/libsasl-ios/lib";
 				PRODUCT_NAME = "etpan-ios";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;

--- a/build-mac/libetpan.xcodeproj/project.pbxproj
+++ b/build-mac/libetpan.xcodeproj/project.pbxproj
@@ -1887,7 +1887,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "cp -R \"$SRCROOT/libsasl-ios/sasl.xcframework\" \"$BUILT_PRODUCTS_DIR\"\n";
+			shellScript = "cp -R \"$SRCROOT/libsasl-ios/lib/sasl.xcframework\" \"$BUILT_PRODUCTS_DIR\"\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 


### PR DESCRIPTION
This change is related purely to cyrus-sasl dependency. Libetpan uses a bunch of scripts to build it internally. I've reorganized build process to
1. Correctly build new architecture (use target triples instead of archs)
2. Split device and simulator builds (they are not going to be merged into single `.a` library now)
3. Assemble xcframework from separate static libraries.